### PR TITLE
add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "description": "HyperCmd Keys lib",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "sodium-universal": "^4.0.1"
+  },
   "devDependencies": {},
   "repository": {
     "type": "git",


### PR DESCRIPTION
during my tests using this command:
`hp-rpc-cli -s "PUB_KEY" -i="XXX-hyper-id.json" -m="ACTION" -d='PAYLOAD" -dt="50001" -ds="SEED"`
i got this error:

```
node:internal/modules/cjs/loader:1148
  throw err;
  ^

Error: Cannot find module 'sodium-universal'
Require stack:
- /Users/XXX/.nvm/versions/node/v20.14.0/lib/node_modules/hp-rpc-cli/node_modules/@hyper-cmd/lib-keys/index.js
- /Users/XXX/.nvm/versions/node/v20.14.0/lib/node_modules/hp-rpc-cli/client.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1145:15)
    at Module._load (node:internal/modules/cjs/loader:986:27)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/Users/XXX/.nvm/versions/node/v20.14.0/lib/node_modules/hp-rpc-cli/node_modules/@hyper-cmd/lib-keys/index.js:1:16)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
    at Module.require (node:internal/modules/cjs/loader:1233:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/XXX/.nvm/versions/node/v20.14.0/lib/node_modules/hp-rpc-cli/node_modules/@hyper-cmd/lib-keys/index.js',
    '/Users/XXX/.nvm/versions/node/v20.14.0/lib/node_modules/hp-rpc-cli/client.js'
  ]
}

Node.js v20.14.0
```